### PR TITLE
Add channel_id to messages and threads streams

### DIFF
--- a/tap_slack/transform.py
+++ b/tap_slack/transform.py
@@ -20,7 +20,7 @@ def transform_json(stream, data, date_fields, channel_id=None):
                         file_ids.append(file_id)
                 record['file_ids'] = file_ids
 
-            if stream == "messages" or "threads":
+            if stream in ["messages", "threads"]:
                 # add channel_id to the message
                 record['channel_id'] = channel_id
 


### PR DESCRIPTION
# Description of change

Channel ID not added correctly to the `messages` and `threads` strams.
The current code is using valid python syntax but the logic is not correct. Probably by a typo or fast coding.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
