### PR TITLE
Fix thread_ts values in messages and threads streams

### DIFF
--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -257,7 +257,7 @@ class ConversationHistoryStream(SlackStream):
                                     # If threads are being synced then the message data for the
                                     # message the threaded replies are in response to will be
                                     # synced to the messages table as well as the threads table
-                                    if threads_stream:
+                                    if threads_stream and data.get('thread_ts'):
                                         # If threads is selected we need to sync all the
                                         # threaded replies to this message
                                         threads_stream.write_schema()
@@ -274,9 +274,7 @@ class ConversationHistoryStream(SlackStream):
                                             schema=schema,
                                             metadata=metadata.to_map(mdata)
                                         )
-                                        record_timestamp = \
-                                            transformed_record.get('thread_ts', '').partition('.')[
-                                                0]
+                                        record_timestamp = data.get('ts', '').partition('.')[0]
                                         record_timestamp_int = int(record_timestamp)
                                         if record_timestamp_int >= start.timestamp():
                                             if self.write_to_singer:

--- a/tap_slack/transform.py
+++ b/tap_slack/transform.py
@@ -33,9 +33,5 @@ def transform_json(stream, data, date_fields, channel_id=None):
             for date_field in date_fields:
                 timestamp = record.get(date_field, None)
                 if timestamp and isinstance(timestamp, str):
-                    if stream == 'messages' or stream == "threads" and date_field == 'ts':
-                        record['thread_ts'] = timestamp
-                        record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
-                    else:
-                        record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
+                    record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
     return data


### PR DESCRIPTION
# Description of change

Cannot join `messages` and `threads` table because `thread_ts` column not populated correctly.

# Manual QA steps

`messages.thread_ts` should be populated by [conversations.history](https://api.slack.com/methods/conversations.history) API endpoint and `threads.thread_ts` should be populated by [conversations.replies](https://api.slack.com/methods/conversations.replies) endpoint 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
