### PR TITLE
Htrueman/source slack bugfix incorrect thread ts

### DIFF
--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -390,6 +390,8 @@ class ThreadsStream(SlackStream):
                                                          date_fields=self.date_fields,
                                                          channel_id=channel_id)
                     for message in transformed_threads:
+                        if message['thread_ts']:
+                            message['thread_ts'] = message['thread_ts'].partition('.')[0]
                         with singer.Transformer(
                                 integer_datetime_fmt="unix-seconds-integer-datetime-parsing") \
                                 as transformer:

--- a/tap_slack/transform.py
+++ b/tap_slack/transform.py
@@ -9,6 +9,7 @@ def decimal_timestamp_to_utc_timestamp(timestamp):
 def transform_json(stream, data, date_fields, channel_id=None):
 
     if data:
+        thread_ts = None
         for record in data:
             if stream == "messages":
                 # Strip out file info and just keep id
@@ -34,8 +35,10 @@ def transform_json(stream, data, date_fields, channel_id=None):
                 timestamp = record.get(date_field, None)
                 if timestamp and isinstance(timestamp, str):
                     if stream == 'messages' or stream == "threads" and date_field == 'ts':
-                        record['thread_ts'] = timestamp
                         record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
+                        if thread_ts is None:
+                            thread_ts = timestamp
+                        record['thread_ts'] = thread_ts
                     else:
                         record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
     return data


### PR DESCRIPTION
# Description of change
Fix `thread_ts` overwrite and apply ISO time format.

# Manual QA steps
Run python `main_dev.py read --config secrets/config.json --catalog sample_files/configured_catalog.json` and check output records.
 
# Risks
Not sure why it was `thread_ts` overwrite previously, perhaps we may miss some of the sync data.
 
# Rollback steps
 - revert this branch
