### PR TITLE
Add is_email_confirmed to users

### DIFF
--- a/tap_slack/schemas/users.json
+++ b/tap_slack/schemas/users.json
@@ -47,6 +47,9 @@
     "is_bot": {
       "type": ["null", "boolean"]
     },
+    "is_email_confirmed": {
+      "type": ["null", "boolean"]
+    },
     "updated": {
       "type": ["null", "string"],
       "format": "date-time"


### PR DESCRIPTION
# Description of change
Add field `is_email_confirmed` to schema users. It indicates whether an invited user has accepted invitation and joined workspace 

Sample slack API response
 {
      "id":"*********",
      "name":"dummy_name",
      "deleted":false,
      "color":"757575",
      "real_name":"dummy_name",
      "tz":"America/Los_Angeles",
      "tz_label":"Pacific Standard Time",
      "tz_offset":-28800,
      "profile":{},
      "is_admin":false,
      "is_owner":false,
      "is_primary_owner":false,
      "is_restricted":false,
      "is_ultra_restricted":false,
      "is_bot":false,
      "is_app_user":false,
      "updated":0,
      **"is_email_confirmed":false,**
      "who_can_share_contact_card":"EVERYONE"
}

# Manual QA steps
 N/A (not sure how to test)
 
# Risks
This field maybe missing from certain API responses depending on the context of each Slack workspace
 
# Rollback steps
 - revert this branch
