### PR TITLE
Added implementation to exclude unauthorized streams from discovery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           name: 'Integration Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            uv pip install .[dev]
             uv pip install --upgrade awscli
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,8 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-slack/bin/activate
             mkdir -p test_output
-            pytest --cov=tap_slack --cov-report=term-missing --junitxml=test_output/unittests.xml tests/unittests
+            export PYTHONPATH="$PWD"
+            python -m pytest --cov=tap_slack --cov-report=term-missing --junitxml=test_output/unittests.xml tests/unittests
           when: always
       - store_test_results:
           path: test_output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,17 @@ jobs:
             uv pip install pylint
             pylint tap_slack -d C,R,W
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-slack/bin/activate
+            mkdir -p test_output
+            pytest --cov=tap_slack --cov-report=term-missing --junitxml=test_output/unittests.xml tests/unittests
+          when: always
+      - store_test_results:
+          path: test_output
+      - store_artifacts:
+          path: htmlcov
+      - run:
           name: 'Integration Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.1
+  * Exclude unauthorized streams (403) from catalog during discovery [#29](https://github.com/singer-io/tap-slack/pull/29)
+
 ## 1.2.0
   * Update slack client to slack sdk and upgrade singer-python version. https://github.com/singer-io/tap-slack/pull/24
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-slack',
-      version='1.2.0',
+      version='1.2.1',
       description='Singer.io tap for extracting data from the Slack Web API',
       author='dwallace@envoy.com',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-slack',
       py_modules=['tap_slack'],
       install_requires=[
           'singer-python==6.8.0',
-          'slack-sdk==3.36.0',
+          'slack-sdk==3.43.0',
       ],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,17 @@ setup(name='tap-slack',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_slack'],
       install_requires=[
-          'singer-python==6.1.1',
+          'singer-python==6.8.0',
           'slack-sdk==3.36.0',
       ],
       extras_require={
           'dev': [
-              'pylint',
-              'ipdb',
-              'nose'
+            'pylint',
+            'ipdb',
+            'nose',
+            'pytest',
+            'pytest-cov',
+            'coverage',
           ]
       },
       entry_points='''

--- a/tap_slack/__init__.py
+++ b/tap_slack/__init__.py
@@ -52,6 +52,7 @@ def _prune_inaccessible_children(streams):
             to_remove.append(stream)
     for stream in to_remove:
         streams.remove(stream)
+    return to_remove
 
 
 def _apply_access_checks(client, streams):
@@ -66,7 +67,7 @@ def _apply_access_checks(client, streams):
             inaccessible_streams.append(stream)
             streams.remove(stream)
 
-    _prune_inaccessible_children(streams)
+    inaccessible_streams.extend(_prune_inaccessible_children(streams))
 
     if not streams:
         raise SlackForbiddenError(
@@ -74,7 +75,7 @@ def _apply_access_checks(client, streams):
         )
     elif inaccessible_streams:
         LOGGER.warning(
-            "These streams have been excluded due to HTTP-Error-Code:403 Forbidden: %s",
+            "Unauthorized streams excluded from catalog: %s",
             ", ".join(s.name for s in inaccessible_streams),
         )
 

--- a/tap_slack/__init__.py
+++ b/tap_slack/__init__.py
@@ -130,14 +130,13 @@ def main():
     args = singer.utils.parse_args(required_config_keys=['token', 'start_date'])
 
     webclient = WebClient(token=args.config.get("token"))
-    client = SlackClient(webclient=webclient, config=args.config)
-
-    if args.discover:
-        discover(client=client)
-    elif args.catalog:
-        if args.config.get("join_public_channels", "false") == "true":
-            auto_join(client=client, config=args.config)
-        sync(client=client, config=args.config, catalog=args.catalog, state=args.state)
+    with SlackClient(webclient=webclient, config=args.config) as client:
+        if args.discover:
+            discover(client=client)
+        elif args.catalog:
+            if args.config.get("join_public_channels", "false") == "true":
+                auto_join(client=client, config=args.config)
+            sync(client=client, config=args.config, catalog=args.catalog, state=args.state)
 
 
 if __name__ == '__main__':

--- a/tap_slack/__init__.py
+++ b/tap_slack/__init__.py
@@ -4,6 +4,7 @@ import singer
 from slack_sdk import WebClient
 
 from tap_slack.client import SlackClient
+from tap_slack.exceptions import SlackForbiddenError
 from tap_slack.streams import AVAILABLE_STREAMS
 from tap_slack.catalog import generate_catalog
 
@@ -34,9 +35,54 @@ def auto_join(client, config):
                 raise Exception('{}: {}'.format(conversation_name, error))
 
 
+def _prune_inaccessible_children(streams):
+    """
+    Remove child streams whose parent stream was excluded.
+    Mutates the streams list in place.
+    """
+    accessible_names = {s.name for s in streams}
+    to_remove = []
+    for stream in streams:
+        parent = getattr(stream, 'parent', None)
+        if parent and parent not in accessible_names:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                stream.name, parent,
+            )
+            to_remove.append(stream)
+    for stream in to_remove:
+        streams.remove(stream)
+
+
+def _apply_access_checks(client, streams):
+    """
+    Probe each stream for read access and remove inaccessible streams
+    (and their children) from the list in place.
+    Raises SlackForbiddenError if no parent streams are accessible.
+    """
+    inaccessible_streams = []
+    for stream in list(streams):
+        if not stream.check_access():
+            inaccessible_streams.append(stream)
+            streams.remove(stream)
+
+    _prune_inaccessible_children(streams)
+
+    if not streams:
+        raise SlackForbiddenError(
+            "No streams are accessible. Ensure the credentials have read permission for at least one stream."
+        )
+    elif inaccessible_streams:
+        LOGGER.warning(
+            "These streams have been excluded due to HTTP-Error-Code:403 Forbidden: %s",
+            ", ".join(s.name for s in inaccessible_streams),
+        )
+
+
 def discover(client):
     LOGGER.info('Starting Discovery..')
     streams = [stream_class(client) for _, stream_class in AVAILABLE_STREAMS.items()]
+    _apply_access_checks(client, streams)
     catalog = generate_catalog(streams)
     json.dump(catalog, sys.stdout, indent=2)
     LOGGER.info("Finished Discovery..")

--- a/tap_slack/client.py
+++ b/tap_slack/client.py
@@ -17,6 +17,13 @@ class SlackClient(object):
         self.webclient = webclient
         self.config = config
 
+    def __enter__(self):
+        self.webclient.auth_test()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
     # pylint: disable=no-self-argument,raising-non-exception
     def wait(err=None):
         if isinstance(err, SlackApiError):

--- a/tap_slack/exceptions.py
+++ b/tap_slack/exceptions.py
@@ -1,0 +1,6 @@
+class SlackForbiddenError(Exception):
+    """
+    Raised when the Slack API returns an error indicating the credentials
+    do not have permission to access a resource (e.g., missing_scope).
+    """
+    pass

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -5,7 +5,9 @@ import pytz
 import singer
 from singer import metadata, utils
 from singer.utils import strptime_to_utc
+from slack_sdk.errors import SlackApiError
 
+from tap_slack.exceptions import SlackForbiddenError
 from tap_slack.transform import transform_json
 
 LOGGER = singer.get_logger()
@@ -25,6 +27,39 @@ class SlackStream:
             self.date_window_size = int(config.get('date_window_size', '7'))
         else:
             self.date_window_size = 7
+
+    # Slack API errors indicating insufficient permissions
+    FORBIDDEN_ERRORS = {"missing_scope", "not_allowed_token_type", "access_denied",
+                        "token_revoked", "account_inactive", "org_login_required"}
+
+    def check_access(self):
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a permission error is raised.
+        Child streams always return True (access is governed by the parent check).
+        """
+        if getattr(self, 'parent', None):
+            return True
+
+        try:
+            self._probe_access()
+            return True
+        except SlackForbiddenError as exc:
+            LOGGER.warning(
+                "Unauthorized Stream: %s, excluding from catalog. Error: '%s'",
+                self.name,
+                exc,
+            )
+            return False
+
+    def _probe_access(self):
+        """
+        Make a minimal API call to verify access to this stream.
+        Subclasses should override if the default is not suitable.
+        """
+        raise NotImplementedError(
+            f"Stream {self.name} must implement _probe_access() for access checking."
+        )
 
     @staticmethod
     def get_abs_path(path):
@@ -110,6 +145,14 @@ class ConversationsStream(SlackStream):
     forced_replication_method = 'FULL_TABLE'
     valid_replication_keys = []
     date_fields = ['created']
+
+    def _probe_access(self):
+        try:
+            self.client.webclient.conversations_list(limit=1)
+        except SlackApiError as err:
+            if err.response.data.get("error", "") in self.FORBIDDEN_ERRORS:
+                raise SlackForbiddenError(err.response.data.get("error", "")) from err
+            raise
 
     def sync(self, mdata):
         schema = self.load_schema()
@@ -323,6 +366,14 @@ class UsersStream(SlackStream):
     valid_replication_keys = ['updated_at']
     date_fields = ['updated']
 
+    def _probe_access(self):
+        try:
+            self.client.webclient.users_list(limit=1)
+        except SlackApiError as err:
+            if err.response.data.get("error", "") in self.FORBIDDEN_ERRORS:
+                raise SlackForbiddenError(err.response.data.get("error", "")) from err
+            raise
+
     def sync(self, mdata):
 
         schema = self.load_schema()
@@ -413,6 +464,14 @@ class UserGroupsStream(SlackStream):
     replication_method = 'FULL_TABLE'
     valid_replication_keys = []
 
+    def _probe_access(self):
+        try:
+            self.client.webclient.usergroups_list()
+        except SlackApiError as err:
+            if err.response.data.get("error", "") in self.FORBIDDEN_ERRORS:
+                raise SlackForbiddenError(err.response.data.get("error", "")) from err
+            raise
+
     def sync(self, mdata):
         schema = self.load_schema()
 
@@ -448,6 +507,14 @@ class TeamsStream(SlackStream):
     valid_replication_keys = ['updated_at']
     date_fields = []
 
+    def _probe_access(self):
+        try:
+            self.client.webclient.team_info()
+        except SlackApiError as err:
+            if err.response.data.get("error", "") in self.FORBIDDEN_ERRORS:
+                raise SlackForbiddenError(err.response.data.get("error", "")) from err
+            raise
+
     def sync(self, mdata):
         schema = self.load_schema()
 
@@ -481,6 +548,14 @@ class FilesStream(SlackStream):
     replication_key = 'updated'
     valid_replication_keys = ['updated_at']
     date_fields = []
+
+    def _probe_access(self):
+        try:
+            self.client.webclient.files_list(count=1)
+        except SlackApiError as err:
+            if err.response.data.get("error", "") in self.FORBIDDEN_ERRORS:
+                raise SlackForbiddenError(err.response.data.get("error", "")) from err
+            raise
 
     def sync(self, mdata):
         schema = self.load_schema()
@@ -559,6 +634,14 @@ class RemoteFilesStream(SlackStream):
     replication_key = 'updated'
     valid_replication_keys = ['updated_at']
     date_fields = []
+
+    def _probe_access(self):
+        try:
+            self.client.webclient.files_remote_list(limit=1)
+        except SlackApiError as err:
+            if err.response.data.get("error", "") in self.FORBIDDEN_ERRORS:
+                raise SlackForbiddenError(err.response.data.get("error", "")) from err
+            raise
 
     def sync(self, mdata):
         schema = self.load_schema()

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -17,6 +17,8 @@ utc = pytz.UTC
 
 class SlackStream:
 
+    name = None
+
     def __init__(self, client, config=None, catalog=None, state=None, write_to_singer=True):
         self.client = client
         self.config = config

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for stream exclusion during discovery.
+Tests that unauthorized streams (403 Forbidden) are excluded from the catalog.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from slack_sdk.errors import SlackApiError
+
+from tap_slack import _apply_access_checks, _prune_inaccessible_children, discover
+from tap_slack.exceptions import SlackForbiddenError
+from tap_slack.streams import (
+    AVAILABLE_STREAMS,
+    ConversationsStream,
+    ConversationMembersStream,
+    ConversationHistoryStream,
+    FilesStream,
+    RemoteFilesStream,
+    TeamsStream,
+    ThreadsStream,
+    UserGroupsStream,
+    UsersStream,
+)
+
+
+def _mock_client():
+    """Create a mock SlackClient."""
+    client = MagicMock()
+    client.config = {}
+    client.webclient = MagicMock()
+    return client
+
+
+def _make_slack_api_error(error_code):
+    """Create a mock SlackApiError with the given error code."""
+    response = MagicMock()
+    response.data = {"ok": False, "error": error_code}
+    response.status_code = 200
+    err = SlackApiError(message=f"The request to the Slack API failed. (error: {error_code})",
+                        response=response)
+    return err
+
+
+class TestCheckAccess(unittest.TestCase):
+    """Test the check_access() method on individual streams."""
+
+    def test_child_stream_always_returns_true(self):
+        """Child streams should always return True regardless of permissions."""
+        client = _mock_client()
+        child_streams = [ConversationMembersStream, ConversationHistoryStream, ThreadsStream]
+        for stream_cls in child_streams:
+            stream = stream_cls(client)
+            self.assertTrue(stream.check_access(),
+                            f"{stream.name} (child) should always return True")
+
+    def test_parent_stream_accessible(self):
+        """Parent stream should return True when API call succeeds."""
+        client = _mock_client()
+        stream = ConversationsStream(client)
+        # Mock webclient method to succeed
+        client.webclient.conversations_list.return_value = {"ok": True, "channels": []}
+        self.assertTrue(stream.check_access())
+
+    def test_parent_stream_forbidden_missing_scope(self):
+        """Parent stream should return False when API returns missing_scope."""
+        client = _mock_client()
+        stream = UsersStream(client)
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+        self.assertFalse(stream.check_access())
+
+    def test_parent_stream_forbidden_logs_warning(self):
+        """check_access() should log a warning with the stream name and error when forbidden."""
+        client = _mock_client()
+        stream = UsersStream(client)
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+
+        with patch('tap_slack.streams.LOGGER') as mock_logger:
+            result = stream.check_access()
+
+        self.assertFalse(result)
+        mock_logger.warning.assert_called_once_with(
+            "Unauthorized Stream: %s, excluding from catalog. Error: '%s'",
+            "users",
+            mock_logger.warning.call_args[0][2],  # the SlackForbiddenError instance
+        )
+        # Verify the error message content
+        logged_exc = mock_logger.warning.call_args[0][2]
+        self.assertIn("missing_scope", str(logged_exc))
+
+    def test_parent_stream_forbidden_not_allowed_token_type(self):
+        """Parent stream should return False when API returns not_allowed_token_type."""
+        client = _mock_client()
+        stream = TeamsStream(client)
+        client.webclient.team_info.side_effect = _make_slack_api_error("not_allowed_token_type")
+        self.assertFalse(stream.check_access())
+
+    def test_parent_stream_forbidden_access_denied(self):
+        """Parent stream should return False when API returns access_denied."""
+        client = _mock_client()
+        stream = FilesStream(client)
+        client.webclient.files_list.side_effect = _make_slack_api_error("access_denied")
+        self.assertFalse(stream.check_access())
+
+    def test_parent_stream_other_error_raises(self):
+        """Parent stream should raise non-permission SlackApiError."""
+        client = _mock_client()
+        stream = ConversationsStream(client)
+        client.webclient.conversations_list.side_effect = _make_slack_api_error("internal_error")
+        with self.assertRaises(SlackApiError):
+            stream.check_access()
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """Test the _apply_access_checks() function."""
+
+    def test_all_streams_accessible(self):
+        """When all streams are accessible, none are removed."""
+        client = _mock_client()
+        # All probe calls succeed
+        client.webclient.conversations_list.return_value = {"ok": True}
+        client.webclient.users_list.return_value = {"ok": True}
+        client.webclient.usergroups_list.return_value = {"ok": True}
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        original_count = len(streams)
+        _apply_access_checks(client, streams)
+        self.assertEqual(len(streams), original_count)
+
+    def test_partial_access_excludes_forbidden_streams(self):
+        """When some streams are forbidden, they are excluded."""
+        client = _mock_client()
+        # conversations succeeds, users fails
+        client.webclient.conversations_list.return_value = {"ok": True}
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.usergroups_list.return_value = {"ok": True}
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        _apply_access_checks(client, streams)
+
+        stream_names = [s.name for s in streams]
+        self.assertNotIn('users', stream_names)
+        # Other streams should still be present
+        self.assertIn('channels', stream_names)
+        self.assertIn('teams', stream_names)
+
+    def test_child_excluded_when_parent_forbidden(self):
+        """When parent stream (channels) is forbidden, its children are excluded."""
+        client = _mock_client()
+        # channels fails, others succeed
+        client.webclient.conversations_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.users_list.return_value = {"ok": True}
+        client.webclient.usergroups_list.return_value = {"ok": True}
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        _apply_access_checks(client, streams)
+
+        stream_names = [s.name for s in streams]
+        # Parent excluded
+        self.assertNotIn('channels', stream_names)
+        # Children excluded
+        self.assertNotIn('channel_members', stream_names)
+        self.assertNotIn('messages', stream_names)
+        self.assertNotIn('threads', stream_names)
+        # Non-children still present
+        self.assertIn('users', stream_names)
+        self.assertIn('teams', stream_names)
+
+    def test_all_forbidden_raises_error(self):
+        """When all parent streams are forbidden, raise SlackForbiddenError."""
+        client = _mock_client()
+        # All probe calls fail
+        client.webclient.conversations_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.usergroups_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.team_info.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.files_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.files_remote_list.side_effect = _make_slack_api_error("missing_scope")
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        with self.assertRaises(SlackForbiddenError) as ctx:
+            _apply_access_checks(client, streams)
+        self.assertIn("No streams are accessible", str(ctx.exception))
+        self.assertIn("read permission for at least one stream", str(ctx.exception))
+
+    def test_all_forbidden_raises_error_message(self):
+        """SlackForbiddenError message should contain the expected text."""
+        client = _mock_client()
+        client.webclient.conversations_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.usergroups_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.team_info.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.files_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.files_remote_list.side_effect = _make_slack_api_error("missing_scope")
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        with self.assertRaises(SlackForbiddenError) as ctx:
+            _apply_access_checks(client, streams)
+        self.assertEqual(
+            str(ctx.exception),
+            "No streams are accessible. Ensure the credentials have read permission for at least one stream."
+        )
+
+    @patch('tap_slack.LOGGER')
+    def test_partial_access_logs_excluded_streams_warning(self, mock_logger):
+        """_apply_access_checks should log a warning listing excluded stream names."""
+        client = _mock_client()
+        client.webclient.conversations_list.return_value = {"ok": True}
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.usergroups_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        _apply_access_checks(client, streams)
+
+        # Find the specific warning call about excluded streams
+        exclusion_calls = [
+            call for call in mock_logger.warning.call_args_list
+            if "excluded due to HTTP-Error-Code:403 Forbidden" in str(call)
+        ]
+        self.assertEqual(len(exclusion_calls), 1)
+        warning_msg = exclusion_calls[0][0][0]
+        excluded_names = exclusion_calls[0][0][1]
+        self.assertEqual(
+            warning_msg,
+            "These streams have been excluded due to HTTP-Error-Code:403 Forbidden: %s"
+        )
+        self.assertIn("users", excluded_names)
+        self.assertIn("user_groups", excluded_names)
+
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """Test the _prune_inaccessible_children() function."""
+
+    def test_children_removed_when_parent_missing(self):
+        """Child streams are removed when their parent is not in the list."""
+        client = _mock_client()
+        # Only include users (no channels parent)
+        streams = [
+            UsersStream(client),
+            ConversationMembersStream(client),  # parent='channels'
+            ThreadsStream(client),  # parent='channels'
+        ]
+        _prune_inaccessible_children(streams)
+        stream_names = [s.name for s in streams]
+        self.assertIn('users', stream_names)
+        self.assertNotIn('channel_members', stream_names)
+        self.assertNotIn('threads', stream_names)
+
+    def test_children_kept_when_parent_present(self):
+        """Child streams are kept when their parent is in the list."""
+        client = _mock_client()
+        streams = [
+            ConversationsStream(client),
+            ConversationMembersStream(client),
+            ConversationHistoryStream(client),
+            ThreadsStream(client),
+        ]
+        _prune_inaccessible_children(streams)
+        stream_names = [s.name for s in streams]
+        self.assertEqual(len(stream_names), 4)
+
+
+class TestDiscoverWithAccessChecks(unittest.TestCase):
+    """Test the full discover() function with access checking."""
+
+    @patch('tap_slack.json.dump')
+    def test_discover_excludes_forbidden_streams(self, mock_json_dump):
+        """discover() should produce a catalog without forbidden streams."""
+        client = _mock_client()
+        # user_groups forbidden
+        client.webclient.conversations_list.return_value = {"ok": True}
+        client.webclient.users_list.return_value = {"ok": True}
+        client.webclient.usergroups_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        discover(client)
+
+        # Verify json.dump was called with the catalog
+        self.assertTrue(mock_json_dump.called)
+        catalog = mock_json_dump.call_args[0][0]
+        stream_names = [s['stream'] for s in catalog['streams']]
+        self.assertNotIn('user_groups', stream_names)
+        self.assertIn('channels', stream_names)
+        self.assertIn('users', stream_names)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -227,17 +227,42 @@ class TestApplyAccessChecks(unittest.TestCase):
         # Find the specific warning call about excluded streams
         exclusion_calls = [
             call for call in mock_logger.warning.call_args_list
-            if "excluded due to HTTP-Error-Code:403 Forbidden" in str(call)
+            if "Unauthorized streams excluded from catalog" in str(call)
         ]
         self.assertEqual(len(exclusion_calls), 1)
         warning_msg = exclusion_calls[0][0][0]
         excluded_names = exclusion_calls[0][0][1]
         self.assertEqual(
             warning_msg,
-            "These streams have been excluded due to HTTP-Error-Code:403 Forbidden: %s"
+            "Unauthorized streams excluded from catalog: %s"
         )
         self.assertIn("users", excluded_names)
         self.assertIn("user_groups", excluded_names)
+
+    @patch('tap_slack.LOGGER')
+    def test_parent_forbidden_warning_includes_pruned_children(self, mock_logger):
+        """When a parent stream is inaccessible, warning should include pruned child stream names."""
+        client = _mock_client()
+        client.webclient.conversations_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.users_list.return_value = {"ok": True}
+        client.webclient.usergroups_list.return_value = {"ok": True}
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        _apply_access_checks(client, streams)
+
+        exclusion_calls = [
+            call for call in mock_logger.warning.call_args_list
+            if "Unauthorized streams excluded from catalog" in str(call)
+        ]
+        self.assertEqual(len(exclusion_calls), 1)
+        excluded_names = exclusion_calls[0][0][1]
+        self.assertIn("channels", excluded_names)
+        self.assertIn("channel_members", excluded_names)
+        self.assertIn("messages", excluded_names)
+        self.assertIn("threads", excluded_names)
 
 
 class TestPruneInaccessibleChildren(unittest.TestCase):

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from tap_slack.client import SlackClient
+
+
+def make_slack_error(code, retry_after="0"):
+    response = MagicMock()
+    response.data = {"ok": False, "error": code}
+    response.headers = {"Retry-After": retry_after}
+    response.status_code = 200
+    return SlackApiError(message=code, response=response)
+
+
+def test_client_wait_rate_limited_sleeps():
+    err = make_slack_error("ratelimited", retry_after="2")
+    with patch("tap_slack.client.time.sleep") as sleep_mock:
+        SlackClient.wait(err)
+    sleep_mock.assert_called_once_with(2)
+
+
+def test_client_wait_non_ratelimited_raises():
+    err = make_slack_error("invalid_auth")
+    with pytest.raises(SlackApiError):
+        SlackClient.wait(err)
+
+
+def test_client_wait_with_non_slack_error_noop():
+    SlackClient.wait(ValueError("x"))
+
+
+def test_client_channel_and_collection_calls_passthrough():
+    webclient = MagicMock()
+    webclient.conversations_info.return_value = {"channel": {"id": "C1"}}
+    webclient.conversations_list.return_value = [{"channels": [{"id": "C1"}]}]
+    webclient.users_list.return_value = [{"members": []}]
+    webclient.usergroups_list.return_value = [{"usergroups": []}]
+    webclient.team_info.return_value = [{"team": {"id": "T1"}}]
+    webclient.files_list.return_value = [{"files": []}]
+    webclient.files_remote_list.return_value = [{"files": []}]
+    webclient.conversations_replies.return_value = [{"messages": []}]
+    webclient.conversations_join.return_value = {"ok": True}
+
+    client = SlackClient(webclient, config={})
+
+    assert list(client.get_channel(include_num_members=1, channel="C1")) == [{"id": "C1"}]
+    assert client.get_all_channels(types="public_channel", exclude_archived="true") == [{"channels": [{"id": "C1"}]}]
+    assert client.get_users(limit=100) == [{"members": []}]
+    assert client.get_user_groups("true", "true", "true") == [{"usergroups": []}]
+    assert client.get_teams() == [{"team": {"id": "T1"}}]
+    assert client.get_files(1, 2) == [{"files": []}]
+    assert client.get_remote_files(1, 2) == [{"files": []}]
+    assert client.get_thread("C1", "1", "true", 1, 2) == [{"messages": []}]
+    assert client.join_channel("C1") == {"ok": True}
+
+
+def test_client_get_channel_members_error_paths():
+    webclient = MagicMock()
+    client = SlackClient(webclient, config={})
+
+    webclient.conversations_members.side_effect = make_slack_error("fetch_members_failed")
+    with patch("tap_slack.client.LOGGER") as logger_mock:
+        assert client.get_channel_members("C1") == []
+    logger_mock.warning.assert_called_once()
+
+    webclient.conversations_members.side_effect = make_slack_error("invalid_auth")
+    with pytest.raises(SlackApiError):
+        client.get_channel_members("C2")
+
+
+def test_client_get_messages_error_paths():
+    webclient = MagicMock()
+    client = SlackClient(webclient, config={})
+
+    webclient.conversations_history.side_effect = make_slack_error("not_in_channel")
+    with patch("tap_slack.client.LOGGER") as logger_mock:
+        assert client.get_messages("C1", 1, 2) is None
+    logger_mock.warning.assert_called_once()
+
+    webclient.conversations_history.side_effect = make_slack_error("invalid_auth")
+    with pytest.raises(SlackApiError):
+        client.get_messages("C2", 1, 2)

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -82,3 +82,52 @@ def test_client_get_messages_error_paths():
     webclient.conversations_history.side_effect = make_slack_error("invalid_auth")
     with pytest.raises(SlackApiError):
         client.get_messages("C2", 1, 2)
+
+
+def test_client_enter_success():
+    webclient = MagicMock()
+    webclient.auth_test.return_value = {"ok": True, "team": "T1"}
+    client = SlackClient(webclient, config={"token": "xoxb-test"})
+
+    with client as entered:
+        assert entered is client
+    webclient.auth_test.assert_called_once_with()
+
+
+def test_client_enter_missing_token_still_calls_auth_test():
+    webclient = MagicMock()
+    client = SlackClient(webclient, config={})
+
+    with client as entered:
+        assert entered is client
+    webclient.auth_test.assert_called_once_with()
+
+
+def test_client_enter_invalid_token_payload_does_not_raise():
+    webclient = MagicMock()
+    webclient.auth_test.return_value = {"ok": False, "error": "invalid_auth"}
+    client = SlackClient(webclient, config={"token": "xoxb-test"})
+
+    with client as entered:
+        assert entered is client
+    webclient.auth_test.assert_called_once_with()
+
+
+def test_client_enter_timeout_error_propagates():
+    webclient = MagicMock()
+    client = SlackClient(webclient, config={"token": "xoxb-test"})
+
+    webclient.auth_test.side_effect = TimeoutError("timeout")
+    with pytest.raises(TimeoutError, match="timeout"):
+        with client:
+            pass
+
+
+def test_client_enter_slack_api_error_propagates():
+    webclient = MagicMock()
+    client = SlackClient(webclient, config={"token": "xoxb-test"})
+
+    webclient.auth_test.side_effect = make_slack_error("invalid_auth")
+    with pytest.raises(SlackApiError, match="invalid_auth"):
+        with client:
+            pass

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for stream exclusion during discovery.
+Tests that unauthorized streams (403 Forbidden) are excluded from the catalog.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from slack_sdk.errors import SlackApiError
+
+from tap_slack import _apply_access_checks, _prune_inaccessible_children, discover
+from tap_slack.exceptions import SlackForbiddenError
+from tap_slack.streams import (
+    AVAILABLE_STREAMS,
+    ConversationsStream,
+    ConversationMembersStream,
+    ConversationHistoryStream,
+    FilesStream,
+    RemoteFilesStream,
+    TeamsStream,
+    ThreadsStream,
+    UserGroupsStream,
+    UsersStream,
+)
+
+
+def _mock_client():
+    """Create a mock SlackClient."""
+    client = MagicMock()
+    client.config = {}
+    client.webclient = MagicMock()
+    return client
+
+
+def _make_slack_api_error(error_code):
+    """Create a mock SlackApiError with the given error code."""
+    response = MagicMock()
+    response.data = {"ok": False, "error": error_code}
+    response.status_code = 200
+    err = SlackApiError(message=f"The request to the Slack API failed. (error: {error_code})",
+                        response=response)
+    return err
+
+
+class TestCheckAccess(unittest.TestCase):
+    """Test the check_access() method on individual streams."""
+
+    def test_child_stream_always_returns_true(self):
+        """Child streams should always return True regardless of permissions."""
+        client = _mock_client()
+        child_streams = [ConversationMembersStream, ConversationHistoryStream, ThreadsStream]
+        for stream_cls in child_streams:
+            stream = stream_cls(client)
+            self.assertTrue(stream.check_access(),
+                            f"{stream.name} (child) should always return True")
+
+    def test_parent_stream_accessible(self):
+        """Parent stream should return True when API call succeeds."""
+        client = _mock_client()
+        stream = ConversationsStream(client)
+        # Mock webclient method to succeed
+        client.webclient.conversations_list.return_value = {"ok": True, "channels": []}
+        self.assertTrue(stream.check_access())
+
+    def test_parent_stream_forbidden_missing_scope(self):
+        """Parent stream should return False when API returns missing_scope."""
+        client = _mock_client()
+        stream = UsersStream(client)
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+        self.assertFalse(stream.check_access())
+
+    def test_parent_stream_forbidden_logs_warning(self):
+        """check_access() should log a warning with the stream name and error when forbidden."""
+        client = _mock_client()
+        stream = UsersStream(client)
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+
+        with patch('tap_slack.streams.LOGGER') as mock_logger:
+            result = stream.check_access()
+
+        self.assertFalse(result)
+        mock_logger.warning.assert_called_once_with(
+            "Unauthorized Stream: %s, excluding from catalog. Error: '%s'",
+            "users",
+            mock_logger.warning.call_args[0][2],  # the SlackForbiddenError instance
+        )
+        # Verify the error message content
+        logged_exc = mock_logger.warning.call_args[0][2]
+        self.assertIn("missing_scope", str(logged_exc))
+
+    def test_parent_stream_forbidden_not_allowed_token_type(self):
+        """Parent stream should return False when API returns not_allowed_token_type."""
+        client = _mock_client()
+        stream = TeamsStream(client)
+        client.webclient.team_info.side_effect = _make_slack_api_error("not_allowed_token_type")
+        self.assertFalse(stream.check_access())
+
+    def test_parent_stream_forbidden_access_denied(self):
+        """Parent stream should return False when API returns access_denied."""
+        client = _mock_client()
+        stream = FilesStream(client)
+        client.webclient.files_list.side_effect = _make_slack_api_error("access_denied")
+        self.assertFalse(stream.check_access())
+
+    def test_parent_stream_other_error_raises(self):
+        """Parent stream should raise non-permission SlackApiError."""
+        client = _mock_client()
+        stream = ConversationsStream(client)
+        client.webclient.conversations_list.side_effect = _make_slack_api_error("internal_error")
+        with self.assertRaises(SlackApiError):
+            stream.check_access()
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """Test the _apply_access_checks() function."""
+
+    def test_all_streams_accessible(self):
+        """When all streams are accessible, none are removed."""
+        client = _mock_client()
+        # All probe calls succeed
+        client.webclient.conversations_list.return_value = {"ok": True}
+        client.webclient.users_list.return_value = {"ok": True}
+        client.webclient.usergroups_list.return_value = {"ok": True}
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        original_count = len(streams)
+        _apply_access_checks(client, streams)
+        self.assertEqual(len(streams), original_count)
+
+    def test_partial_access_excludes_forbidden_streams(self):
+        """When some streams are forbidden, they are excluded."""
+        client = _mock_client()
+        # conversations succeeds, users fails
+        client.webclient.conversations_list.return_value = {"ok": True}
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.usergroups_list.return_value = {"ok": True}
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        _apply_access_checks(client, streams)
+
+        stream_names = [s.name for s in streams]
+        self.assertNotIn('users', stream_names)
+        # Other streams should still be present
+        self.assertIn('channels', stream_names)
+        self.assertIn('teams', stream_names)
+
+    def test_child_excluded_when_parent_forbidden(self):
+        """When parent stream (channels) is forbidden, its children are excluded."""
+        client = _mock_client()
+        # channels fails, others succeed
+        client.webclient.conversations_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.users_list.return_value = {"ok": True}
+        client.webclient.usergroups_list.return_value = {"ok": True}
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        _apply_access_checks(client, streams)
+
+        stream_names = [s.name for s in streams]
+        # Parent excluded
+        self.assertNotIn('channels', stream_names)
+        # Children excluded
+        self.assertNotIn('channel_members', stream_names)
+        self.assertNotIn('messages', stream_names)
+        self.assertNotIn('threads', stream_names)
+        # Non-children still present
+        self.assertIn('users', stream_names)
+        self.assertIn('teams', stream_names)
+
+    def test_all_forbidden_raises_error(self):
+        """When all parent streams are forbidden, raise SlackForbiddenError."""
+        client = _mock_client()
+        # All probe calls fail
+        client.webclient.conversations_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.usergroups_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.team_info.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.files_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.files_remote_list.side_effect = _make_slack_api_error("missing_scope")
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        with self.assertRaises(SlackForbiddenError) as ctx:
+            _apply_access_checks(client, streams)
+        self.assertIn("No streams are accessible", str(ctx.exception))
+        self.assertIn("read permission for at least one stream", str(ctx.exception))
+
+    def test_all_forbidden_raises_error_message(self):
+        """SlackForbiddenError message should contain the expected text."""
+        client = _mock_client()
+        client.webclient.conversations_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.usergroups_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.team_info.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.files_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.files_remote_list.side_effect = _make_slack_api_error("missing_scope")
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        with self.assertRaises(SlackForbiddenError) as ctx:
+            _apply_access_checks(client, streams)
+        self.assertEqual(
+            str(ctx.exception),
+            "No streams are accessible. Ensure the credentials have read permission for at least one stream."
+        )
+
+    @patch('tap_slack.LOGGER')
+    def test_partial_access_logs_excluded_streams_warning(self, mock_logger):
+        """_apply_access_checks should log a warning listing excluded stream names."""
+        client = _mock_client()
+        client.webclient.conversations_list.return_value = {"ok": True}
+        client.webclient.users_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.usergroups_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        _apply_access_checks(client, streams)
+
+        # Find the specific warning call about excluded streams
+        exclusion_calls = [
+            call for call in mock_logger.warning.call_args_list
+            if "excluded due to HTTP-Error-Code:403 Forbidden" in str(call)
+        ]
+        self.assertEqual(len(exclusion_calls), 1)
+        warning_msg = exclusion_calls[0][0][0]
+        excluded_names = exclusion_calls[0][0][1]
+        self.assertEqual(
+            warning_msg,
+            "These streams have been excluded due to HTTP-Error-Code:403 Forbidden: %s"
+        )
+        self.assertIn("users", excluded_names)
+        self.assertIn("user_groups", excluded_names)
+
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """Test the _prune_inaccessible_children() function."""
+
+    def test_children_removed_when_parent_missing(self):
+        """Child streams are removed when their parent is not in the list."""
+        client = _mock_client()
+        # Only include users (no channels parent)
+        streams = [
+            UsersStream(client),
+            ConversationMembersStream(client),  # parent='channels'
+            ThreadsStream(client),  # parent='channels'
+        ]
+        _prune_inaccessible_children(streams)
+        stream_names = [s.name for s in streams]
+        self.assertIn('users', stream_names)
+        self.assertNotIn('channel_members', stream_names)
+        self.assertNotIn('threads', stream_names)
+
+    def test_children_kept_when_parent_present(self):
+        """Child streams are kept when their parent is in the list."""
+        client = _mock_client()
+        streams = [
+            ConversationsStream(client),
+            ConversationMembersStream(client),
+            ConversationHistoryStream(client),
+            ThreadsStream(client),
+        ]
+        _prune_inaccessible_children(streams)
+        stream_names = [s.name for s in streams]
+        self.assertEqual(len(stream_names), 4)
+
+
+class TestDiscoverWithAccessChecks(unittest.TestCase):
+    """Test the full discover() function with access checking."""
+
+    @patch('tap_slack.json.dump')
+    def test_discover_excludes_forbidden_streams(self, mock_json_dump):
+        """discover() should produce a catalog without forbidden streams."""
+        client = _mock_client()
+        # user_groups forbidden
+        client.webclient.conversations_list.return_value = {"ok": True}
+        client.webclient.users_list.return_value = {"ok": True}
+        client.webclient.usergroups_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        discover(client)
+
+        # Verify json.dump was called with the catalog
+        self.assertTrue(mock_json_dump.called)
+        catalog = mock_json_dump.call_args[0][0]
+        stream_names = [s['stream'] for s in catalog['streams']]
+        self.assertNotIn('user_groups', stream_names)
+        self.assertIn('channels', stream_names)
+        self.assertIn('users', stream_names)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -227,17 +227,42 @@ class TestApplyAccessChecks(unittest.TestCase):
         # Find the specific warning call about excluded streams
         exclusion_calls = [
             call for call in mock_logger.warning.call_args_list
-            if "excluded due to HTTP-Error-Code:403 Forbidden" in str(call)
+            if "Unauthorized streams excluded from catalog" in str(call)
         ]
         self.assertEqual(len(exclusion_calls), 1)
         warning_msg = exclusion_calls[0][0][0]
         excluded_names = exclusion_calls[0][0][1]
         self.assertEqual(
             warning_msg,
-            "These streams have been excluded due to HTTP-Error-Code:403 Forbidden: %s"
+            "Unauthorized streams excluded from catalog: %s"
         )
         self.assertIn("users", excluded_names)
         self.assertIn("user_groups", excluded_names)
+
+    @patch('tap_slack.LOGGER')
+    def test_parent_forbidden_warning_includes_pruned_children(self, mock_logger):
+        """When a parent stream is inaccessible, warning should include pruned child stream names."""
+        client = _mock_client()
+        client.webclient.conversations_list.side_effect = _make_slack_api_error("missing_scope")
+        client.webclient.users_list.return_value = {"ok": True}
+        client.webclient.usergroups_list.return_value = {"ok": True}
+        client.webclient.team_info.return_value = {"ok": True}
+        client.webclient.files_list.return_value = {"ok": True}
+        client.webclient.files_remote_list.return_value = {"ok": True}
+
+        streams = [stream_cls(client) for _, stream_cls in AVAILABLE_STREAMS.items()]
+        _apply_access_checks(client, streams)
+
+        exclusion_calls = [
+            call for call in mock_logger.warning.call_args_list
+            if "Unauthorized streams excluded from catalog" in str(call)
+        ]
+        self.assertEqual(len(exclusion_calls), 1)
+        excluded_names = exclusion_calls[0][0][1]
+        self.assertIn("channels", excluded_names)
+        self.assertIn("channel_members", excluded_names)
+        self.assertIn("messages", excluded_names)
+        self.assertIn("threads", excluded_names)
 
 
 class TestPruneInaccessibleChildren(unittest.TestCase):

--- a/tests/unittests/test_main_sync.py
+++ b/tests/unittests/test_main_sync.py
@@ -1,0 +1,210 @@
+import runpy
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tap_slack import auto_join, main, sync
+
+
+def test_auto_join_with_explicit_channel_list_success():
+    client = MagicMock()
+    client.join_channel.return_value = {"ok": True}
+    auto_join(client, {"channels": ["C1", "C2"]})
+    assert client.join_channel.call_count == 2
+
+
+def test_auto_join_with_explicit_channel_list_failure_raises():
+    client = MagicMock()
+    client.join_channel.return_value = {"ok": False, "error": "not_in_channel"}
+    with pytest.raises(Exception):
+        auto_join(client, {"channels": ["C1"]})
+
+
+def test_auto_join_without_channel_list_uses_public_channels():
+    client = MagicMock()
+    client.get_all_channels.return_value = {
+        "channels": [{"id": "C1", "name": "general"}, {"id": "C2", "name": "random"}]
+    }
+    client.join_channel.return_value = {"ok": True}
+
+    auto_join(client, {})
+
+    assert client.get_all_channels.called
+    assert client.join_channel.call_count == 2
+
+
+def test_auto_join_without_channel_list_failure_raises_with_name():
+    client = MagicMock()
+    client.get_all_channels.return_value = {
+        "channels": [{"id": "C1", "name": "general"}]
+    }
+    client.join_channel.return_value = {"ok": False, "error": "channel_not_found"}
+
+    with pytest.raises(Exception):
+        auto_join(client, {})
+
+
+def test_sync_includes_messages_when_threads_selected():
+    class FakeStream:
+        def __init__(self, client, config=None, catalog=None, state=None, write_to_singer=True):
+            self.write_to_singer = write_to_singer
+
+        def write_schema(self):
+            pass
+
+        def sync(self, mdata):
+            pass
+
+        def write_state(self):
+            pass
+
+    class Entry:
+        def __init__(self, stream):
+            self.stream = stream
+            self.metadata = []
+
+    class FakeCatalog:
+        def get_selected_streams(self, state):
+            return [Entry("threads")]
+
+        def get_stream(self, name):
+            return Entry(name)
+
+    created = []
+
+    class CapturingFake(FakeStream):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    with patch.dict(
+        "tap_slack.AVAILABLE_STREAMS",
+        {
+            "messages": CapturingFake,
+            "threads": CapturingFake,
+        },
+        clear=False,
+    ):
+        sync(client=MagicMock(), config={}, catalog=FakeCatalog(), state={})
+
+    assert len(created) == 1
+    assert created[0].write_to_singer is False
+
+
+def test_sync_uses_write_to_singer_true_when_messages_selected():
+    class FakeStream:
+        def __init__(self, client, config=None, catalog=None, state=None, write_to_singer=True):
+            self.write_to_singer = write_to_singer
+
+        def write_schema(self):
+            pass
+
+        def sync(self, mdata):
+            pass
+
+        def write_state(self):
+            pass
+
+    class Entry:
+        def __init__(self, stream):
+            self.stream = stream
+            self.metadata = []
+
+    class FakeCatalog:
+        def get_selected_streams(self, state):
+            return [Entry("messages")]
+
+        def get_stream(self, name):
+            return Entry(name)
+
+    created = []
+
+    class CapturingFake(FakeStream):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    with patch.dict("tap_slack.AVAILABLE_STREAMS", {"messages": CapturingFake}, clear=False):
+        sync(client=MagicMock(), config={}, catalog=FakeCatalog(), state={})
+
+    assert len(created) == 1
+    assert created[0].write_to_singer is True
+
+
+def test_sync_sets_false_when_no_messages_or_threads_selected():
+    class FakeStream:
+        def __init__(self, client, config=None, catalog=None, state=None, write_to_singer=True):
+            self.write_to_singer = write_to_singer
+
+        def write_schema(self):
+            pass
+
+        def sync(self, mdata):
+            pass
+
+        def write_state(self):
+            pass
+
+    class Entry:
+        def __init__(self, stream):
+            self.stream = stream
+            self.metadata = []
+
+    class FakeCatalog:
+        def get_selected_streams(self, state):
+            return [Entry("channels")]
+
+        def get_stream(self, name):
+            return Entry(name)
+
+    created = []
+
+    class CapturingFake(FakeStream):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    with patch.dict("tap_slack.AVAILABLE_STREAMS", {"channels": CapturingFake}, clear=False):
+        sync(client=MagicMock(), config={}, catalog=FakeCatalog(), state={})
+
+    assert len(created) == 1
+    assert created[0].write_to_singer is True
+
+
+def test_main_discover_and_sync_paths():
+    parse_discover = SimpleNamespace(discover=True, config={"token": "x"}, catalog=None, state={})
+    parse_sync = SimpleNamespace(
+        discover=False,
+        config={"token": "x", "join_public_channels": "true"},
+        catalog=object(),
+        state={},
+    )
+
+    with patch("tap_slack.singer.utils.parse_args", return_value=parse_discover), patch(
+        "tap_slack.WebClient"
+    ) as webclient_cls, patch("tap_slack.SlackClient") as slack_client_cls, patch(
+        "tap_slack.discover"
+    ) as discover_mock:
+        main()
+        webclient_cls.assert_called_once_with(token="x")
+        slack_client_cls.assert_called_once()
+        discover_mock.assert_called_once()
+
+    with patch("tap_slack.singer.utils.parse_args", return_value=parse_sync), patch(
+        "tap_slack.WebClient"
+    ), patch("tap_slack.SlackClient"), patch("tap_slack.sync") as sync_mock, patch(
+        "tap_slack.auto_join"
+    ) as auto_join_mock:
+        main()
+        auto_join_mock.assert_called_once()
+        sync_mock.assert_called_once()
+
+
+def test_module_main_guard_executes_main():
+    parse_args = SimpleNamespace(discover=False, config={"token": "x"}, catalog=None, state={})
+
+    with patch("singer.utils.parse_args", return_value=parse_args), patch(
+        "slack_sdk.WebClient"
+    ), patch("tap_slack.client.SlackClient"):
+        runpy.run_module("tap_slack.__init__", run_name="__main__")

--- a/tests/unittests/test_streams_missing.py
+++ b/tests/unittests/test_streams_missing.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -47,6 +48,37 @@ class DummyTransformer:
         return data
 
 
+class FakeMoment:
+    def __init__(self, gt_result=False, lt_result=False):
+        self.gt_result = gt_result
+        self.lt_result = lt_result
+
+    def replace(self, **kwargs):
+        return self
+
+    def __gt__(self, other):
+        return self.gt_result
+
+    def __lt__(self, other):
+        return self.lt_result
+
+    def strftime(self, fmt):
+        return "2025-01-01T00:00:00"
+
+
+def make_fake_datetime_module(moment_map):
+    def fake_utcfromtimestamp(timestamp):
+        return moment_map[timestamp]["utc"]
+
+    def fake_fromtimestamp(timestamp):
+        return moment_map[timestamp]["from"]
+
+    return SimpleNamespace(
+        utcfromtimestamp=fake_utcfromtimestamp,
+        fromtimestamp=fake_fromtimestamp,
+    )
+
+
 def make_slack_error(code):
     response = MagicMock()
     response.data = {"ok": False, "error": code}
@@ -90,6 +122,20 @@ def test_all_channels_defaults_to_public_and_not_archived_filter():
     client.get_all_channels.assert_called_once_with(
         types="public_channel", exclude_archived="false"
     )
+
+
+def test_get_absolute_date_range_uses_config_start_when_outside_lookback():
+    client = MagicMock()
+    stream = ConversationsStream(
+        client=client,
+        config={"lookback_window": "14"},
+        state={},
+    )
+
+    start, end = stream.get_absolute_date_range("2025-01-01T00:00:00Z")
+
+    assert start < end
+    assert start.year == 2025
 
 
 @pytest.mark.parametrize(
@@ -171,6 +217,124 @@ def test_messages_sync_with_threads_selected_calls_thread_stream_methods():
     end = datetime(2025, 1, 2, tzinfo=timezone.utc)
 
     with patch("tap_slack.streams.ThreadsStream", DummyThreadsStream), patch(
+        "tap_slack.streams.singer.metrics.job_timer", side_effect=dummy_job_timer
+    ), patch(
+        "tap_slack.streams.singer.metrics.record_counter", side_effect=lambda **_: DummyCounter()
+    ), patch(
+        "tap_slack.streams.singer.Transformer", DummyTransformer
+    ), patch(
+        "tap_slack.streams.metadata.to_map", side_effect=lambda m: m
+    ), patch(
+        "tap_slack.streams.singer.write_record"
+    ), patch(
+        "tap_slack.streams.singer.utils.now", return_value=datetime(2025, 1, 2, tzinfo=timezone.utc)
+    ), patch.object(
+        stream, "get_absolute_date_range", return_value=(start, end)
+    ):
+        stream.sync(mdata=[])
+
+
+def test_messages_sync_covers_bookmark_comparison_branches():
+    class DummyEntry:
+        def __init__(self, stream):
+            self.stream = stream
+            self.metadata = []
+
+    class DummyCatalog:
+        def get_selected_streams(self, state):
+            return [DummyEntry("messages")]
+
+    client = MagicMock()
+    stream = ConversationHistoryStream(
+        client=client,
+        config={"start_date": "2025-01-01T00:00:00Z", "date_window_size": "1"},
+        catalog=DummyCatalog(),
+        state={"bookmarks": {}},
+    )
+    stream.load_schema = MagicMock(return_value={"type": "object"})
+
+    client.get_all_channels.return_value = [{"channels": [{"id": "C1"}]}]
+    client.get_messages.return_value = [
+        {
+            "messages": [
+                {"ts": "1735689700.100", "thread_ts": "1735689700.100", "text": "newer"},
+                {"ts": "1735689600.100", "thread_ts": "1735689600.100", "text": "older"},
+            ]
+        }
+    ]
+
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+    moment_map = {
+        1735689700: {"utc": FakeMoment(gt_result=True, lt_result=False), "from": FakeMoment(gt_result=True, lt_result=False)},
+        1735689600: {"utc": FakeMoment(gt_result=False, lt_result=True), "from": FakeMoment(gt_result=False, lt_result=True)},
+    }
+
+    with patch("tap_slack.streams.datetime", make_fake_datetime_module(moment_map)), patch(
+        "tap_slack.streams.singer.metrics.job_timer", side_effect=dummy_job_timer
+    ), patch(
+        "tap_slack.streams.singer.metrics.record_counter", side_effect=lambda **_: DummyCounter()
+    ), patch(
+        "tap_slack.streams.singer.Transformer", DummyTransformer
+    ), patch(
+        "tap_slack.streams.metadata.to_map", side_effect=lambda m: m
+    ), patch(
+        "tap_slack.streams.singer.write_record"
+    ), patch(
+        "tap_slack.streams.singer.utils.now", return_value=datetime(2025, 1, 2, tzinfo=timezone.utc)
+    ), patch.object(
+        stream, "get_absolute_date_range", return_value=(start, end)
+    ):
+        stream.sync(mdata=[])
+
+
+@pytest.mark.parametrize(
+    "stream_cls, client_attr, moment_map, start_field, end_field",
+    [
+        (
+            FilesStream,
+            "get_files",
+            {
+                1735689700: {"utc": FakeMoment(gt_result=True, lt_result=False), "from": FakeMoment(gt_result=True, lt_result=False)},
+                1735689600: {"utc": FakeMoment(gt_result=False, lt_result=True), "from": FakeMoment(gt_result=False, lt_result=True)},
+            },
+            "timestamp",
+            "files",
+        ),
+        (
+            RemoteFilesStream,
+            "get_remote_files",
+            {
+                1735689700: {"utc": FakeMoment(gt_result=True, lt_result=False), "from": FakeMoment(gt_result=True, lt_result=False)},
+                1735689600: {"utc": FakeMoment(gt_result=False, lt_result=True), "from": FakeMoment(gt_result=False, lt_result=True)},
+            },
+            "timestamp",
+            "files",
+        ),
+    ],
+)
+def test_files_and_remote_files_cover_min_bookmark_branch(stream_cls, client_attr, moment_map, start_field, end_field):
+    client = MagicMock()
+    stream = stream_cls(
+        client=client,
+        config={"start_date": "2025-01-01T00:00:00Z", "date_window_size": "1"},
+        state={"bookmarks": {}},
+    )
+    stream.load_schema = MagicMock(return_value={"type": "object"})
+
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+
+    getattr(client, client_attr).return_value = [
+        {
+            end_field: [
+                {"id": "A", start_field: 1735689700},
+                {"id": "B", start_field: 1735689600},
+            ]
+        }
+    ]
+
+    with patch("tap_slack.streams.datetime", make_fake_datetime_module(moment_map)), patch(
         "tap_slack.streams.singer.metrics.job_timer", side_effect=dummy_job_timer
     ), patch(
         "tap_slack.streams.singer.metrics.record_counter", side_effect=lambda **_: DummyCounter()

--- a/tests/unittests/test_streams_missing.py
+++ b/tests/unittests/test_streams_missing.py
@@ -1,0 +1,188 @@
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from tap_slack.streams import (
+    ConversationHistoryStream,
+    ConversationsStream,
+    FilesStream,
+    RemoteFilesStream,
+    SlackStream,
+    TeamsStream,
+    UserGroupsStream,
+    UsersStream,
+)
+
+
+@contextmanager
+def dummy_job_timer(**kwargs):
+    yield None
+
+
+class DummyCounter:
+    def increment(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyTransformer:
+    def __init__(self, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def transform(self, data, schema, metadata):
+        return data
+
+
+def make_slack_error(code):
+    response = MagicMock()
+    response.data = {"ok": False, "error": code}
+    response.status_code = 200
+    return SlackApiError(message=code, response=response)
+
+
+def test_base_stream_probe_access_raises_not_implemented():
+    class DummyStream(SlackStream):
+        name = "dummy"
+        key_properties = ["id"]
+
+    stream = DummyStream(client=MagicMock(), config={})
+    with pytest.raises(NotImplementedError):
+        stream._probe_access()
+
+
+def test_write_schema_calls_singer_write_schema():
+    class DummyStream(SlackStream):
+        name = "dummy"
+        key_properties = ["id"]
+
+    stream = DummyStream(client=MagicMock(), config={})
+    with patch.object(stream, "load_schema", return_value={"type": "object"}), patch(
+        "tap_slack.streams.singer.write_schema"
+    ) as write_schema_mock:
+        stream.write_schema()
+
+    write_schema_mock.assert_called_once_with(
+        stream_name="dummy", schema={"type": "object"}, key_properties=["id"]
+    )
+
+
+def test_all_channels_defaults_to_public_and_not_archived_filter():
+    client = MagicMock()
+    client.get_all_channels.return_value = [{"channels": []}]
+
+    stream = ConversationsStream(client=client, config={}, state={})
+    list(stream._all_channels())
+
+    client.get_all_channels.assert_called_once_with(
+        types="public_channel", exclude_archived="false"
+    )
+
+
+@pytest.mark.parametrize(
+    "stream_cls, webclient_method",
+    [
+        (UsersStream, "users_list"),
+        (UserGroupsStream, "usergroups_list"),
+        (TeamsStream, "team_info"),
+        (FilesStream, "files_list"),
+        (RemoteFilesStream, "files_remote_list"),
+    ],
+)
+def test_probe_access_reraises_non_forbidden_errors(stream_cls, webclient_method):
+    client = MagicMock()
+    client.webclient = MagicMock()
+    getattr(client.webclient, webclient_method).side_effect = make_slack_error("internal_error")
+
+    stream = stream_cls(client=client, config={}, state={})
+    with pytest.raises(SlackApiError):
+        stream._probe_access()
+
+
+def test_messages_bookmark_helpers_cover_missing_paths():
+    stream = ConversationHistoryStream(client=MagicMock(), config={}, catalog=MagicMock(), state=None)
+    assert stream.get_bookmark("C1", "default") == "default"
+
+    stream.state = {}
+    with patch.object(stream, "write_state") as write_state_mock:
+        stream.update_bookmarks("C1", "2025-01-01T00:00:00")
+
+    assert stream.state["bookmarks"]["messages"]["C1"] == "2025-01-01T00:00:00"
+    write_state_mock.assert_called_once()
+
+
+def test_messages_sync_with_threads_selected_calls_thread_stream_methods():
+    class DummyEntry:
+        def __init__(self, stream):
+            self.stream = stream
+            self.metadata = []
+
+    class DummyCatalog:
+        def get_selected_streams(self, state):
+            return [DummyEntry("threads")]
+
+    class DummyThreadsStream:
+        def __init__(self, *args, **kwargs):
+            self.write_schema_called = 0
+            self.write_state_called = 0
+            self.sync_called = 0
+
+        def write_schema(self):
+            self.write_schema_called += 1
+
+        def sync(self, mdata, channel_id, ts):
+            self.sync_called += 1
+
+        def write_state(self):
+            self.write_state_called += 1
+
+    client = MagicMock()
+    stream = ConversationHistoryStream(
+        client=client,
+        config={"start_date": "2025-01-01T00:00:00Z", "date_window_size": "1"},
+        catalog=DummyCatalog(),
+        state={"bookmarks": {}},
+    )
+    stream.load_schema = MagicMock(return_value={"type": "object"})
+
+    client.get_all_channels.return_value = [{"channels": [{"id": "C1"}]}]
+    client.get_messages.return_value = [
+        {
+            "messages": [
+                {"ts": "1735689600.100", "thread_ts": "1735689600.100", "text": "one"}
+            ]
+        }
+    ]
+
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+
+    with patch("tap_slack.streams.ThreadsStream", DummyThreadsStream), patch(
+        "tap_slack.streams.singer.metrics.job_timer", side_effect=dummy_job_timer
+    ), patch(
+        "tap_slack.streams.singer.metrics.record_counter", side_effect=lambda **_: DummyCounter()
+    ), patch(
+        "tap_slack.streams.singer.Transformer", DummyTransformer
+    ), patch(
+        "tap_slack.streams.metadata.to_map", side_effect=lambda m: m
+    ), patch(
+        "tap_slack.streams.singer.write_record"
+    ), patch(
+        "tap_slack.streams.singer.utils.now", return_value=datetime(2025, 1, 2, tzinfo=timezone.utc)
+    ), patch.object(
+        stream, "get_absolute_date_range", return_value=(start, end)
+    ):
+        stream.sync(mdata=[])

--- a/tests/unittests/test_streams_unit.py
+++ b/tests/unittests/test_streams_unit.py
@@ -1,0 +1,281 @@
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tap_slack.streams import (
+    ConversationHistoryStream,
+    ConversationMembersStream,
+    ConversationsStream,
+    FilesStream,
+    RemoteFilesStream,
+    TeamsStream,
+    ThreadsStream,
+    UserGroupsStream,
+    UsersStream,
+)
+
+
+@contextmanager
+def dummy_job_timer(**kwargs):
+    yield None
+
+
+class DummyCounter:
+    def __init__(self):
+        self.value = 0
+
+    def increment(self):
+        self.value += 1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyTransformer:
+    def __init__(self, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def transform(self, data, schema, metadata):
+        return data
+
+
+@pytest.fixture
+def patched_stream_env():
+    with patch("tap_slack.streams.singer.metrics.job_timer", side_effect=dummy_job_timer), patch(
+        "tap_slack.streams.singer.metrics.record_counter", side_effect=lambda **_: DummyCounter()
+    ), patch("tap_slack.streams.singer.Transformer", DummyTransformer), patch(
+        "tap_slack.streams.metadata.to_map", side_effect=lambda m: m
+    ), patch("tap_slack.streams.singer.write_record"), patch(
+        "tap_slack.streams.singer.write_state"
+    ), patch(
+        "tap_slack.streams.singer.utils.now", return_value=datetime(2025, 1, 2, tzinfo=timezone.utc)
+    ):
+        yield
+
+
+def make_client():
+    client = MagicMock()
+    client.config = {}
+    client.webclient = MagicMock()
+    return client
+
+
+def test_slackstream_helpers_and_channel_selection(patched_stream_env):
+    client = make_client()
+    stream = ConversationsStream(client=client, config={"private_channels": "true"}, state={})
+
+    assert stream.load_schema()["type"] == ["null", "object"]
+    assert stream.get_bookmark("x", "default") == "default"
+
+    stream.state = {}
+    stream.update_bookmarks("x", "2025-01-01T00:00:00")
+    assert stream.state["bookmarks"]["x"] == "2025-01-01T00:00:00"
+
+    start, end = stream.get_absolute_date_range("2025-01-01T00:00:00Z")
+    assert start.tzinfo is not None
+    assert end.tzinfo is not None
+
+    client.get_all_channels.return_value = [{"channels": [{"id": "C1"}, {"id": "C2"}]}]
+    assert list(stream.channels()) == [{"id": "C1"}, {"id": "C2"}]
+
+    stream.config = {"channels": ["C10", "C20"]}
+    client.get_channel.side_effect = [{"id": "C10"}, {"id": "C20"}]
+    assert list(stream.channels()) == [{"id": "C10"}, {"id": "C20"}]
+
+
+def test_conversations_and_members_sync_write_records(patched_stream_env):
+    client = make_client()
+
+    conv = ConversationsStream(client=client, config={}, state={})
+    conv.load_schema = MagicMock(return_value={"type": "object"})
+    client.get_all_channels.return_value = [{"channels": [{"id": "C1"}, {"id": "C2"}]}]
+    conv.sync(mdata=[])
+    assert client.get_all_channels.called
+
+    members = ConversationMembersStream(client=client, config={}, state={})
+    members.load_schema = MagicMock(return_value={"type": "object"})
+    client.get_all_channels.return_value = [{"channels": [{"id": "C1"}]}]
+    client.get_channel_members.return_value = [{"members": ["U1", "U2"]}]
+    members.sync(mdata=[])
+    assert client.get_channel_members.called
+
+
+def test_users_sync_incremental_bookmark_paths(patched_stream_env):
+    client = make_client()
+    stream = UsersStream(
+        client=client,
+        config={"start_date": "2025-01-01T00:00:00Z"},
+        state={"bookmarks": {}},
+    )
+    stream.load_schema = MagicMock(return_value={"type": "object"})
+
+    client.get_users.return_value = [
+        {
+            "members": [
+                {"id": "U1", "updated": "2025-01-01T00:00:00"},
+                {"id": "U2", "updated": "2025-01-03T00:00:00"},
+            ]
+        }
+    ]
+
+    stream.sync(mdata=[])
+    assert client.get_users.called
+
+    with patch("tap_slack.streams.singer.get_bookmark", return_value="2025-01-04T00:00:00"):
+        stream.sync(mdata=[])
+
+
+def test_threads_sync_records(patched_stream_env):
+    client = make_client()
+    stream = ThreadsStream(
+        client=client,
+        config={"start_date": "2025-01-01T00:00:00Z"},
+        state={"bookmarks": {}},
+    )
+    stream.load_schema = MagicMock(return_value={"type": "object"})
+
+    with patch.object(
+        stream,
+        "get_absolute_date_range",
+        return_value=(
+            datetime(2025, 1, 1, tzinfo=timezone.utc),
+            datetime(2025, 1, 2, tzinfo=timezone.utc),
+        ),
+    ):
+        client.get_thread.return_value = [
+            {
+                "messages": [
+                    {"ts": "1735689600.001", "last_read": "1735689600.001", "text": "r1"}
+                ]
+            }
+        ]
+        stream.sync(mdata=[], channel_id="C1", ts="1735689600.001")
+
+
+def test_usergroups_and_teams_sync(patched_stream_env):
+    client = make_client()
+
+    ug = UserGroupsStream(client=client, config={}, state={})
+    ug.load_schema = MagicMock(return_value={"type": "object"})
+    client.get_user_groups.return_value = [{"usergroups": [{"id": "G1"}, {"id": "G2"}]}]
+    ug.sync(mdata=[])
+
+    teams = TeamsStream(client=client, config={}, state={})
+    teams.load_schema = MagicMock(return_value={"type": "object"})
+    client.get_teams.return_value = [{"team": {"id": "T1"}}]
+    teams.sync(mdata=[])
+
+
+def test_files_and_remote_files_sync_and_bookmarks(patched_stream_env):
+    client = make_client()
+
+    files = FilesStream(
+        client=client,
+        config={"start_date": "2025-01-01T00:00:00Z", "date_window_size": "1"},
+        state={"bookmarks": {}},
+    )
+    files.load_schema = MagicMock(return_value={"type": "object"})
+
+    remote = RemoteFilesStream(
+        client=client,
+        config={"start_date": "2025-01-01T00:00:00Z", "date_window_size": "1"},
+        state={"bookmarks": {}},
+    )
+    remote.load_schema = MagicMock(return_value={"type": "object"})
+
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+
+    client.get_files.return_value = [{"files": [{"id": "F1", "timestamp": int(start.timestamp()) + 10}]}]
+    client.get_remote_files.return_value = [
+        {"files": [{"id": "RF1", "timestamp": int(start.timestamp()) + 20}]}
+    ]
+
+    with patch.object(files, "get_absolute_date_range", return_value=(start, end)):
+        files.sync(mdata=[])
+
+    with patch.object(remote, "get_absolute_date_range", return_value=(start, end)):
+        remote.sync(mdata=[])
+
+
+def test_messages_sync_updates_channel_bookmarks(patched_stream_env):
+    client = make_client()
+    state = {"bookmarks": {}}
+
+    class DummyEntry:
+        def __init__(self, stream):
+            self.stream = stream
+            self.metadata = []
+
+    class DummyCatalog:
+        def get_selected_streams(self, state):
+            return [DummyEntry("messages")]
+
+    stream = ConversationHistoryStream(
+        client=client,
+        config={"start_date": "2025-01-01T00:00:00Z", "date_window_size": "1"},
+        catalog=DummyCatalog(),
+        state=state,
+    )
+    stream.load_schema = MagicMock(return_value={"type": "object"})
+
+    client.get_all_channels.return_value = [{"channels": [{"id": "C1"}]}]
+    client.get_messages.return_value = [
+        {
+            "messages": [
+                {"ts": "1735689600.100", "text": "m1", "thread_ts": "1735689600.100"},
+                {"ts": "1735689600.200", "text": "m2", "thread_ts": "1735689600.200"},
+            ]
+        }
+    ]
+
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+
+    with patch.object(stream, "get_absolute_date_range", return_value=(start, end)):
+        stream.sync(mdata=[])
+
+    assert "messages" in stream.state["bookmarks"]
+    assert "C1" in stream.state["bookmarks"]["messages"]
+
+
+def test_messages_sync_handles_none_messages_page(patched_stream_env):
+    client = make_client()
+    state = {"bookmarks": {}}
+
+    class DummyEntry:
+        def __init__(self, stream):
+            self.stream = stream
+            self.metadata = []
+
+    class DummyCatalog:
+        def get_selected_streams(self, state):
+            return [DummyEntry("messages")]
+
+    stream = ConversationHistoryStream(
+        client=client,
+        config={"start_date": "2025-01-01T00:00:00Z", "date_window_size": "1"},
+        catalog=DummyCatalog(),
+        state=state,
+    )
+    stream.load_schema = MagicMock(return_value={"type": "object"})
+
+    client.get_all_channels.return_value = [{"channels": [{"id": "C1"}]}]
+    client.get_messages.return_value = None
+
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+
+    with patch.object(stream, "get_absolute_date_range", return_value=(start, end)):
+        stream.sync(mdata=[])

--- a/tests/unittests/test_transform.py
+++ b/tests/unittests/test_transform.py
@@ -1,0 +1,37 @@
+from tap_slack.transform import decimal_timestamp_to_utc_timestamp, transform_json
+
+
+def test_decimal_timestamp_to_utc_timestamp():
+    assert decimal_timestamp_to_utc_timestamp("1712345678.123456") == "1712345678"
+
+
+def test_transform_json_messages_and_channels_and_threads():
+    messages = [
+        {
+            "ts": "1712345678.123456",
+            "files": [{"id": "F1"}, {"name": "missing-id"}],
+            "text": "hello",
+        }
+    ]
+    out_messages = transform_json("messages", messages, ["ts"], channel_id="C1")
+    assert out_messages[0]["file_ids"] == ["F1"]
+    assert out_messages[0]["channel_id"] == "C1"
+    assert out_messages[0]["ts"] == "1712345678"
+    assert out_messages[0]["thread_ts"] == "1712345678.123456"
+
+    channels = [{"id": "C1", "parent_conversation": "abc", "channel_id": "old"}]
+    out_channels = transform_json("channels", channels, [])
+    assert "parent_conversation" not in out_channels[0]
+    assert "channel_id" not in out_channels[0]
+
+    threads = [{"ts": "1712345678.999", "last_read": "1712345000.000"}]
+    out_threads = transform_json("threads", threads, ["ts", "last_read"], channel_id="C2")
+    assert out_threads[0]["channel_id"] == "C2"
+    assert out_threads[0]["thread_ts"] == "1712345678.999"
+    assert out_threads[0]["ts"] == "1712345678"
+    assert out_threads[0]["last_read"] == "1712345000"
+
+
+def test_transform_json_with_empty_input():
+    assert transform_json("users", [], ["updated"]) == []
+    assert transform_json("users", None, ["updated"]) is None


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31247
Excluded unauthorized streams from catalog during discovery
Child streams are automatically excluded when their parent stream is inaccessible.
Added unit test case and updated integration test accordingly

# Manual QA steps
  - [x]  Discovery: Running
 - [x]  Sync: Running
 - [x]  Unit Tests: Running
 - [x]  Integration test: Running 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
